### PR TITLE
feat: 인증 처리 로직 구현

### DIFF
--- a/src/main/java/com/moa/global/auth/model/Claims.java
+++ b/src/main/java/com/moa/global/auth/model/Claims.java
@@ -1,0 +1,5 @@
+package com.moa.global.auth.model;
+
+import java.util.List;
+
+public record Claims(Long userId, List<String> role) {}

--- a/src/main/java/com/moa/global/config/SecurityConfig.java
+++ b/src/main/java/com/moa/global/config/SecurityConfig.java
@@ -5,6 +5,7 @@ import com.moa.global.config.sub.SecurityServiceBeanConfig;
 import com.moa.global.filter.BusinessExceptionHandlerFilter;
 import com.moa.global.filter.JwtAuthenticationFilter;
 import com.moa.global.filter.LoginProcessFilter;
+import com.moa.global.filter.handler.RecruitmentAuthorizationManager;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -23,6 +24,7 @@ public class SecurityConfig {
     private final LoginProcessFilter loginProcessFilter;
     private final JwtAuthenticationFilter jwtAuthenticationFilter;
     private final BusinessExceptionHandlerFilter businessExceptionHandlerFilter;
+    private final RecruitmentAuthorizationManager recruitmentAuthorizationManager;
 
     @Bean
     public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
@@ -37,6 +39,7 @@ public class SecurityConfig {
                 .authorizeHttpRequests(authorize ->
                         authorize
                                 .requestMatchers(DELETE, "/user/sign-out").hasRole("USER")
+                                .requestMatchers("/recruitment/*/**").access(recruitmentAuthorizationManager)
                                 .anyRequest().permitAll()
                 );
 

--- a/src/main/java/com/moa/global/config/sub/SecurityServiceBeanConfig.java
+++ b/src/main/java/com/moa/global/config/sub/SecurityServiceBeanConfig.java
@@ -1,5 +1,7 @@
 package com.moa.global.config.sub;
 
+import com.moa.domain.member.ApplimentMemberRepository;
+import com.moa.global.filter.handler.RecruitmentAuthorizationManager;
 import com.moa.service.UserService;
 import org.springframework.context.MessageSource;
 import org.springframework.context.annotation.Bean;
@@ -29,5 +31,10 @@ public class SecurityServiceBeanConfig {
     @Bean
     public PasswordEncoder passwordEncoder() {
         return new BCryptPasswordEncoder();
+    }
+
+    @Bean
+    public RecruitmentAuthorizationManager recruitmentAuthorizationManager(ApplimentMemberRepository applimentMemberRepository) {
+        return new RecruitmentAuthorizationManager(applimentMemberRepository);
     }
 }

--- a/src/main/java/com/moa/global/filter/handler/JwtProviderHandler.java
+++ b/src/main/java/com/moa/global/filter/handler/JwtProviderHandler.java
@@ -8,8 +8,11 @@ import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.core.Authentication;
+import org.springframework.security.core.GrantedAuthority;
 import org.springframework.security.web.authentication.AuthenticationSuccessHandler;
 import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
 
 @RequiredArgsConstructor
 public class JwtProviderHandler implements AuthenticationSuccessHandler {
@@ -20,11 +23,13 @@ public class JwtProviderHandler implements AuthenticationSuccessHandler {
     @Override
     @Transactional
     public void onAuthenticationSuccess(HttpServletRequest request, HttpServletResponse response, Authentication authentication) {
-        String email = ((SecurityUser) authentication.getPrincipal()).getEmail();
+        SecurityUser securityUser = (SecurityUser) authentication.getPrincipal();
+        Long id = securityUser.getId();
+        List<GrantedAuthority> authorities = (List<GrantedAuthority>) securityUser.getAuthorities();
 
-        TokenMapping token = jwtService.createToken(email);
+        TokenMapping token = jwtService.createToken(id, authorities);
         jwtService.sendBothToken(response, token.accessToken(), token.refreshToken());
-        userRepository.findByEmail(email).get()
+        userRepository.findById(id).get()
                 .updateRefreshToken(token.refreshToken());
     }
 }

--- a/src/main/java/com/moa/global/filter/handler/RecruitmentAuthorizationManager.java
+++ b/src/main/java/com/moa/global/filter/handler/RecruitmentAuthorizationManager.java
@@ -1,0 +1,35 @@
+package com.moa.global.filter.handler;
+
+import com.moa.domain.member.ApplimentMemberRepository;
+import com.moa.global.auth.model.JwtUser;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.authorization.AuthorizationDecision;
+import org.springframework.security.authorization.AuthorizationManager;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.web.access.intercept.RequestAuthorizationContext;
+
+import java.util.function.Supplier;
+
+@RequiredArgsConstructor
+public class RecruitmentAuthorizationManager implements AuthorizationManager<RequestAuthorizationContext> {
+
+    private final ApplimentMemberRepository applimentMemberRepository;
+
+    @Override
+    public AuthorizationDecision check(Supplier<Authentication> authentication, RequestAuthorizationContext context) {
+        JwtUser user = (JwtUser) authentication.get().getPrincipal();
+        String requestURI = context.getRequest().getRequestURI();
+        return new AuthorizationDecision(canAccess(user, requestURI));
+    }
+
+    private boolean canAccess(JwtUser user, String requestURI) {
+        return applimentMemberRepository.findAllRecruitmentByUserId(user.id()).stream()
+                .map(am -> am.getRecruitMember().getRecruitment().getId())
+                .anyMatch(recruitmentId -> match(recruitmentId, requestURI));
+    }
+
+    private boolean match(Long recruitmentId, String requestURI) {
+        String[] parsingUri = requestURI.split("/");
+        return parsingUri[2].equals(String.valueOf(recruitmentId));
+    }
+}

--- a/src/test/java/com/moa/global/auth/utils/JwtServiceTest.java
+++ b/src/test/java/com/moa/global/auth/utils/JwtServiceTest.java
@@ -8,6 +8,7 @@ import org.junit.jupiter.api.Test;
 import org.springframework.mock.web.MockHttpServletRequest;
 import org.springframework.mock.web.MockHttpServletResponse;
 
+import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 
@@ -33,10 +34,10 @@ class JwtServiceTest {
     @DisplayName("토큰 생성")
     void createToken() {
         //given
-        String email = "user@email.com";
+        Long id = 1L;
 
         //when
-        TokenMapping token = jwtService.createToken(email);
+        TokenMapping token = jwtService.createToken(id, List.of(() -> "ROLE_USER"));
 
         //then
         assertThat(token.accessToken()).isNotNull();
@@ -47,10 +48,10 @@ class JwtServiceTest {
     @DisplayName("토큰 헤더 통해 전달")
     void sendToken() {
         //given
-        String email = "user@email.com";
+        Long id = 1L;
 
         //when
-        TokenMapping token = jwtService.createToken(email);
+        TokenMapping token = jwtService.createToken(id,  List.of(() -> "ROLE_USER"));
         MockHttpServletResponse response = new MockHttpServletResponse();
         jwtService.sendBothToken(response, token.accessToken(), token.refreshToken());
 
@@ -108,22 +109,22 @@ class JwtServiceTest {
     @DisplayName("유저 이메일 정보 확인")
     void extractUserEmail() {
         //given
-        String email = "user@email.com";
-        String accessToken = jwtService.createAccessToken(email);
+        Long id = 1L;
+        String accessToken = jwtService.createAccessToken(id,  List.of(() -> "ROLE_USER"));
 
         //when
-        String extractEmail = jwtService.extractUserEmail(accessToken);
+        Long userId = jwtService.extractClaims(accessToken).userId();
 
         //then
-        assertThat(extractEmail).isEqualTo(email);
+        assertThat(userId).isEqualTo(id);
     }
 
     @Test
     @DisplayName("유효 시간 지나지 않은 토큰 사용")
     void useValidToken() {
         //given
-        String email = "user@email.com";
-        TokenMapping token = jwtService.createToken(email);
+        Long id = 1L;
+        TokenMapping token = jwtService.createToken(id,  List.of(() -> "ROLE_USER"));
 
         //when
         boolean isAccessTokenValid = jwtService.isTokenValid(token.accessToken().replace("Bearer ", ""));
@@ -138,8 +139,8 @@ class JwtServiceTest {
     @DisplayName("유효 시간 지난 토큰 사용 검증 실패")
     void useInvalidToken() throws InterruptedException {
         //given
-        String email = "user@email.com";
-        TokenMapping token = jwtService.createToken(email);
+        Long id = 1L;
+        TokenMapping token = jwtService.createToken(id, List.of(() -> "ROLE_USER"));
 
         //when
         sleep(1000);


### PR DESCRIPTION
Issue: #50 

## DONE
- JWT Claim 값 변경
    기존: 사용자 이메일 값만 가짐
    변경 후 : 사용자 아이디, 권한
- /recruitment 이하 경로에 대해서 권한 처리
    AuthorizationManager 사용하여 uri에 맞게 동적 권한 처리 