### PR TITLE
fix: 시간 저장 리스트 사이즈 1일경우 저장 로직 추가

### DIFF
--- a/src/main/java/com/moa/dto/possible/PossibleTimeRequest.java
+++ b/src/main/java/com/moa/dto/possible/PossibleTimeRequest.java
@@ -15,16 +15,16 @@ public record PossibleTimeRequest(
         @NotNull @Valid
         List<LocalDateTime> possibleTimeDataList
 ) {
-    public void sortTime() {
-        Collections.sort(possibleTimeDataList);
-    }
-
     public List<PossibleTime> getEntityList(ApplimentMember applimentMember) {
         Collections.sort(this.possibleTimeDataList);
         List<PossibleTime> possibleTimes = new ArrayList<>();
 
         LocalDateTime before = possibleTimeDataList.get(0);
         int startIdx = 0;
+
+        if (possibleTimeDataList.size() == 1) {
+            possibleTimes.add(new PossibleTime(applimentMember, before, before));
+        }
 
         for (int idx = 1; idx < this.possibleTimeDataList.size(); idx++) {
             LocalDateTime current = possibleTimeDataList.get(idx);

--- a/src/main/java/com/moa/dto/recruit/RecruitInfoResponse.java
+++ b/src/main/java/com/moa/dto/recruit/RecruitInfoResponse.java
@@ -5,7 +5,7 @@ import com.moa.domain.recruit.Recruitment;
 import com.moa.domain.recruit.tag.RecruitTag;
 import com.moa.domain.user.User;
 import com.moa.dto.member.RecruitMemberResponse;
-import com.moa.dto.user.UserIdNameResponse;
+import com.moa.dto.user.UserIdNameNicknameResponse;
 import lombok.Getter;
 
 import java.util.List;
@@ -16,7 +16,7 @@ public class RecruitInfoResponse {
     private final String content;
     private final int state;
     private final String category;
-    private UserIdNameResponse postUser;
+    private UserIdNameNicknameResponse postUser;
     private List<String> tags;
     private List<RecruitMemberResponse> members;
 
@@ -31,7 +31,7 @@ public class RecruitInfoResponse {
     }
 
     private void setPostUser(User user) {
-        this.postUser = new UserIdNameResponse(user.getId(), user.getName());
+        this.postUser = new UserIdNameNicknameResponse(user.getId(), user.getName(), user.getNickname());
     }
 
     private void setTags(List<RecruitTag> tags) {

--- a/src/main/java/com/moa/dto/user/UserIdNameNicknameResponse.java
+++ b/src/main/java/com/moa/dto/user/UserIdNameNicknameResponse.java
@@ -1,0 +1,8 @@
+package com.moa.dto.user;
+
+public record UserIdNameNicknameResponse(
+        Long userId,
+        String userName,
+        String nickname
+) {
+}


### PR DESCRIPTION
Issue: #113 

## DONE
- 요청 리스트 사이즈가 1일 경우에(가능 시간이 30분일 경우) 사라지는 문제가 있어서 추가했습니다
- 모집 글 조회 시 작성자 nickname 추가